### PR TITLE
Increase uWSGI header buffer 4096 to 32768 bytes

### DIFF
--- a/root/etc/services.d/apprise-api/run
+++ b/root/etc/services.d/apprise-api/run
@@ -4,4 +4,4 @@
 cd /app/apprise-api/apprise_api || exit
 
 exec \
-    s6-setuidgid abc /usr/sbin/uwsgi --http-socket=:8000 --enable-threads --plugin=python3 --module=core.wsgi:application --static-map=/s=static
+    s6-setuidgid abc /usr/sbin/uwsgi --http-socket=:8000 --enable-threads --plugin=python3 --module=core.wsgi:application --static-map=/s=static --buffer-size=32768


### PR DESCRIPTION
Avoid error "invalid HTTP request size (max 4096)...skip" and follow best practice https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html